### PR TITLE
fix 'calender' to 'calendar'

### DIFF
--- a/templates/partials/menu.nunjucks
+++ b/templates/partials/menu.nunjucks
@@ -19,7 +19,7 @@
                 </ul>
             </li>
             <li>
-                <a href="./calender.html">Calender</a>
+                <a href="./calender.html">Calendar</a>
             </li>
             <li class="more">
                 <a href="#">About Us</a>


### PR DESCRIPTION
Fix a typo in the menu bar, 'Calender' to 'Calendar'.